### PR TITLE
feat: expose API version header

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -68,6 +68,11 @@ paths:
                   - token_type
                   - expires_in
                 additionalProperties: false
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
         "400":
           description: Default Response
           content:
@@ -82,6 +87,11 @@ paths:
                 required:
                   - error
                 additionalProperties: false
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
         "401":
           description: Default Response
           content:
@@ -96,6 +106,11 @@ paths:
                 required:
                   - error
                 additionalProperties: false
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
   /users:
     get:
       summary: List users
@@ -132,6 +147,11 @@ paths:
                     - email
                     - name
                   additionalProperties: false
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
         "401":
           description: Default Response
           content:
@@ -146,6 +166,11 @@ paths:
                 required:
                   - error
                 additionalProperties: false
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
     post:
       summary: Create user
       tags:
@@ -198,6 +223,11 @@ paths:
                   - email
                   - name
                 additionalProperties: false
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
         "400":
           description: Default Response
           content:
@@ -212,6 +242,11 @@ paths:
                 required:
                   - error
                 additionalProperties: false
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
         "401":
           description: Default Response
           content:
@@ -226,6 +261,11 @@ paths:
                 required:
                   - error
                 additionalProperties: false
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
   /users/{id}:
     get:
       summary: Get one user
@@ -266,6 +306,11 @@ paths:
                   - email
                   - name
                 additionalProperties: false
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
         "401":
           description: Default Response
           content:
@@ -280,6 +325,11 @@ paths:
                 required:
                   - error
                 additionalProperties: false
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
         "404":
           description: Default Response
           content:
@@ -294,5 +344,10 @@ paths:
                 required:
                   - error
                 additionalProperties: false
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
 servers:
   - url: http://localhost:3000

--- a/scripts/export-openapi.ts
+++ b/scripts/export-openapi.ts
@@ -6,6 +6,23 @@ import { buildApp } from '../src/server';
   const app = await buildApp();
   await app.ready();
   const spec = app.swagger();
+  // Add x-api-version header to all responses
+  const version = spec.info?.version as string | undefined;
+  if (spec.paths) {
+    for (const path of Object.values(spec.paths)) {
+      for (const method of Object.values(path as any)) {
+        if (method.responses) {
+          for (const response of Object.values(method.responses)) {
+            const headers = (response as any).headers ?? {};
+            headers['x-api-version'] = {
+              schema: { type: 'string', example: version },
+            };
+            (response as any).headers = headers;
+          }
+        }
+      }
+    }
+  }
   writeFileSync('openapi.yaml', YAML.stringify(spec));
 //   writeFileSync('openapi.json', JSON.stringify(spec, null, 2));
   await app.close();

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,4 +9,5 @@ export const config = {
   JWT_SECRET: process.env.JWT_SECRET ?? 'dev-secret-change-me',
   OAUTH2_AUTH_URL: process.env.OAUTH2_AUTH_URL ?? 'https://example/authorize',
   OAUTH2_TOKEN_URL: process.env.OAUTH2_TOKEN_URL ?? 'https://example/token',
+  API_VERSION: process.env.API_VERSION ?? '1.0.0',
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,7 +27,7 @@ export async function buildApp() {
       info: {
         title: 'Typescript boilerplate',
         description: 'Fastify + Zod + Swagger + OAuth2 (client_credentials)',
-        version: '1.0.0',
+        version: config.API_VERSION,
       },
       servers: [{ url: `http://localhost:${config.PORT}` }],
       components: {
@@ -60,6 +60,13 @@ export async function buildApp() {
   app.setErrorHandler((err, _req, reply) => {
     return reply.status(500).send(ApiError.serverError());
   });
+
+    // Add x-api-version header to all responses
+    app.addHook('onSend', async (_req, reply, payload) => {
+    reply.header('x-api-version', config.API_VERSION);
+    return payload;
+  });
+
 
   // Auth gate (uses AccessControlService.verifyBearer)
   const requireAuth = async (req: any, reply: any) => {


### PR DESCRIPTION
## Summary
- add API_VERSION to config and surface in OpenAPI info
- send `x-api-version` header on all responses
- document `x-api-version` in generated OpenAPI spec

## Testing
- `npm run build`
- `npm run openapi:gen`


------
https://chatgpt.com/codex/tasks/task_e_689f6dd0aad4832fbb09d7cff01dc6ff