### PR TITLE
feat: include API version header in all responses

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -48,6 +48,12 @@ paths:
       responses:
         "200":
           description: Default Response
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
+              description: API version
           content:
             application/json:
               schema:
@@ -70,6 +76,12 @@ paths:
                 additionalProperties: false
         "400":
           description: Default Response
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
+              description: API version
           content:
             application/json:
               schema:
@@ -84,6 +96,12 @@ paths:
                 additionalProperties: false
         "401":
           description: Default Response
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
+              description: API version
           content:
             application/json:
               schema:
@@ -108,6 +126,12 @@ paths:
       responses:
         "200":
           description: Default Response
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
+              description: API version
           content:
             application/json:
               schema:
@@ -134,6 +158,12 @@ paths:
                   additionalProperties: false
         "401":
           description: Default Response
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
+              description: API version
           content:
             application/json:
               schema:
@@ -176,6 +206,12 @@ paths:
       responses:
         "200":
           description: Default Response
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
+              description: API version
           content:
             application/json:
               schema:
@@ -200,6 +236,12 @@ paths:
                 additionalProperties: false
         "400":
           description: Default Response
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
+              description: API version
           content:
             application/json:
               schema:
@@ -214,6 +256,12 @@ paths:
                 additionalProperties: false
         "401":
           description: Default Response
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
+              description: API version
           content:
             application/json:
               schema:
@@ -244,6 +292,12 @@ paths:
       responses:
         "200":
           description: Default Response
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
+              description: API version
           content:
             application/json:
               schema:
@@ -268,6 +322,12 @@ paths:
                 additionalProperties: false
         "401":
           description: Default Response
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
+              description: API version
           content:
             application/json:
               schema:
@@ -282,6 +342,12 @@ paths:
                 additionalProperties: false
         "404":
           description: Default Response
+          headers:
+            x-api-version:
+              schema:
+                type: string
+                example: 1.0.0
+              description: API version
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary
- add a global `x-api-version` header to every response
- document the new header across all responses in the OpenAPI spec

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm run openapi:gen`


------
https://chatgpt.com/codex/tasks/task_e_689f77406120832fae79f2863d413829