### PR TITLE
Enforce user scope checks on user endpoints

### DIFF
--- a/features/steps/oauth.steps.ts
+++ b/features/steps/oauth.steps.ts
@@ -4,6 +4,27 @@ import { strict as assert } from 'assert';
 import { TestWorld } from './world';
 import { TokenDao } from '../../src/dao/TokenDao';
 
+async function obtainClientToken(world: TestWorld, scope = 'user') {
+  const params = new URLSearchParams({
+    grant_type: 'client_credentials',
+    client_id: 'my-client',
+    client_secret: 'supersecret',
+  });
+  if (scope !== undefined) {
+    params.set('scope', scope);
+  }
+
+  await world.inject({
+    method: 'POST',
+    url: '/oauth/tokens',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    payload: params.toString(),
+  });
+  const body = world.res.json();
+  world.token = body.access_token;
+  assert.ok(world.token, 'Expected access_token from token endpoint');
+}
+
 When('I POST form to {string} with:', async function (
   this: TestWorld,
   path: string,
@@ -41,16 +62,11 @@ Then(
 );
 
 When('I obtain an access token', async function (this: TestWorld) {
-  await this.inject({
-    method: 'POST',
-    url: '/oauth/tokens',
-    headers: { 'content-type': 'application/x-www-form-urlencoded' },
-    payload:
-      'grant_type=client_credentials&client_id=my-client&client_secret=supersecret&scope=read:users',
-  });
-  const body = this.res.json();
-  this.token = body.access_token;
-  assert.ok(this.token, 'Expected access_token from token endpoint');
+  await obtainClientToken(this, 'user');
+});
+
+When('I obtain an access token with scope {string}', async function (this: TestWorld, scope: string) {
+  await obtainClientToken(this, scope);
 });
 
 When('I fast-forward token storage by {int} seconds', function (this: TestWorld, secs: number) {

--- a/features/steps/users.steps.ts
+++ b/features/steps/users.steps.ts
@@ -3,16 +3,33 @@ import { strict as assert } from 'assert';
 import { TestWorld } from './world';
 import { UserService } from '../../src/services/UserService';
 
-Given('I have a valid access token', async function (this: TestWorld) {
-  await this.inject({
+async function obtainClientToken(world: TestWorld, scope = 'user') {
+  const params = new URLSearchParams({
+    grant_type: 'client_credentials',
+    client_id: 'my-client',
+    client_secret: 'supersecret',
+  });
+  if (scope !== undefined) {
+    params.set('scope', scope);
+  }
+
+  await world.inject({
     method: 'POST',
     url: '/oauth/tokens',
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
-    payload: 'grant_type=client_credentials&client_id=my-client&client_secret=supersecret&scope=read:users',
+    payload: params.toString(),
   });
-  const body = this.res.json();
-  this.token = body.access_token;
-  assert.ok(this.token, 'Expected access_token');
+  const body = world.res.json();
+  world.token = body.access_token;
+  assert.ok(world.token, 'Expected access_token');
+}
+
+Given('I have a valid access token', async function (this: TestWorld) {
+  await obtainClientToken(this, 'user');
+});
+
+Given('I have an access token with scope {string}', async function (this: TestWorld, scope: string) {
+  await obtainClientToken(this, scope);
 });
 
 When('I GET {string}', async function (this: TestWorld, path: string) {

--- a/features/users.feature
+++ b/features/users.feature
@@ -11,6 +11,12 @@ Feature: Users API
     Then the response status should be 200
     And the response json should be an array
 
+  Scenario: Token without user scope cannot list users
+    Given I have an access token with scope "read:users"
+    When I GET "/users"
+    Then the response status should be 403
+    And the response json should have "error" = "insufficient_scope"
+
   Scenario: Get a user that doesn't exist
     Given I have a valid access token
     When I GET "/users/does-not-exist"
@@ -38,6 +44,15 @@ Feature: Users API
     Then the response status should be 200
     And the response json should have a string at "id"
     And the response json should have "email" = "new@user.com"
+
+  Scenario: Token without user scope cannot create user
+    Given I have an access token with scope "read:users"
+    When I POST json to "/users" with:
+      """
+      { "email": "denied@user.com", "name": "Denied User" }
+      """
+    Then the response status should be 403
+    And the response json should have "error" = "insufficient_scope"
 
   Scenario: Invalid token should be rejected
     When I GET "/users" with bearer "nope"

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ export const config = {
   ACCESS_TOKEN_TTL: Number(process.env.ACCESS_TOKEN_TTL ?? 3600),
   CLIENT_ID: process.env.CLIENT_ID ?? 'my-client',
   CLIENT_SECRET: process.env.CLIENT_SECRET ?? 'supersecret',
-  CLIENT_SCOPE: process.env.CLIENT_SCOPE ?? 'read:users',
+  CLIENT_SCOPE: process.env.CLIENT_SCOPE ?? 'user',
   JWT_SECRET: process.env.JWT_SECRET ?? 'dev-secret-change-me',
   OAUTH2_AUTH_URL: process.env.OAUTH2_AUTH_URL ?? 'https://example/authorize',
   OAUTH2_TOKEN_URL: process.env.OAUTH2_TOKEN_URL ?? 'https://example/token',

--- a/src/models/ApiError.ts
+++ b/src/models/ApiError.ts
@@ -18,6 +18,7 @@ export class ApiError implements ErrorResponse {
   static invalidRequest(msg: string)                { return new ApiError('invalid_request', msg); }
   static invalidClient(msg: string)                 { return new ApiError('invalid_client', msg); }
   static invalidToken(msg: string)                  { return new ApiError('invalid_token', msg); }
+  static insufficientScope(msg: string)            { return new ApiError('insufficient_scope', msg); }
   static unsupportedGrantType(msg: string)          { return new ApiError('unsupported_grant_type', msg); }
   static notFound(msg: string)                      { return new ApiError('not_found', msg); }
   static serverError(msg = 'Internal server error') { return new ApiError('server_error', msg); }

--- a/src/routes/oauth.ts
+++ b/src/routes/oauth.ts
@@ -22,7 +22,7 @@ export async function registerOAuthRoutes(app: FastifyInstance) {
       },
     },
     handler: async (req, reply) => {
-      const { grant_type, client_id, client_secret} = req.body as z.infer<
+      const { grant_type, client_id, client_secret, scope } = req.body as z.infer<
         typeof TokenRequestSchema
       >;
 
@@ -39,13 +39,14 @@ export async function registerOAuthRoutes(app: FastifyInstance) {
         return reply.code(401).send(ApiError.invalidClient('Client authentication failed'));
       }
 
-      const { token, expiresIn } = await issueAccessToken(client_id, config.CLIENT_SCOPE);
+      const requestedScope = scope ?? config.CLIENT_SCOPE;
+      const { token, expiresIn } = await issueAccessToken(client_id, requestedScope);
 
       return reply.send({
         access_token: token,
         token_type: 'Bearer',
         expires_in: expiresIn,
-        scope: config.CLIENT_SCOPE
+        scope: requestedScope,
       });
     },
   });

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -4,17 +4,21 @@ import { UserSchema, CreateUserSchema } from '../models/User';
 import { ApiError, ErrorResponseSchema } from '../models/ApiError';
 import { UserService } from '../services/UserService';
 
-export async function registerUserRoutes(app: FastifyInstance, requireAuth: (req: any, reply: any) => Promise<any>) {
+export async function registerUserRoutes(
+  app: FastifyInstance,
+  requireAuth: (scope?: string) => (req: any, reply: any) => Promise<any>
+) {
   app.route({
     method: 'GET',
     url: '/users',
-    preHandler: requireAuth,
+    preHandler: requireAuth('user'),
     schema: {
       tags: ['users'],
-      security: [{ bearer: [] }, { oauth2: ['read:users'] }],
+      security: [{ bearer: [] }, { oauth2: ['user'] }],
       response: {
         200: UserSchema.array(),
         401: ErrorResponseSchema,
+        403: ErrorResponseSchema,
       },
       summary: 'List users',
     },
@@ -24,15 +28,16 @@ export async function registerUserRoutes(app: FastifyInstance, requireAuth: (req
   app.route({
     method: 'GET',
     url: '/users/:id',
-    preHandler: requireAuth,
+    preHandler: requireAuth('user'),
     schema: {
       tags: ['users'],
-      security: [{ bearer: [] }, { oauth2: ['read:users'] }],
+      security: [{ bearer: [] }, { oauth2: ['user'] }],
       params: z.object({ id: z.string() }),
       response: {
         200: UserSchema,
         401: ErrorResponseSchema,
         404: ErrorResponseSchema,
+        403: ErrorResponseSchema,
       },
       summary: 'Get one user',
     },
@@ -49,15 +54,16 @@ export async function registerUserRoutes(app: FastifyInstance, requireAuth: (req
   app.route({
     method: 'POST',
     url: '/users',
-    preHandler: requireAuth,
+    preHandler: requireAuth('user'),
     schema: {
       tags: ['users'],
-      security: [{ bearer: [] }, { oauth2: ['write:users'] }],
+      security: [{ bearer: [] }, { oauth2: ['user'] }],
       body: CreateUserSchema,
       response: {
         200: UserSchema,
         400: ErrorResponseSchema,
         401: ErrorResponseSchema,
+        403: ErrorResponseSchema,
       },
       summary: 'Create user',
     },

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,6 +48,7 @@ export async function buildApp() {
                 authorizationUrl: config.OAUTH2_AUTH_URL,
                 tokenUrl: config.OAUTH2_TOKEN_URL,
                 scopes: {
+                  user: 'Access user resources',
                   'read:users': 'Read users',
                   'write:users': 'Write users',
                 },
@@ -82,19 +83,29 @@ export async function buildApp() {
   });
 
   // Auth gate (uses AccessControlService.verifyBearer)
-  const requireAuth = async (req: any, reply: any) => {
-    const auth = req.headers.authorization;
-    if (!auth?.startsWith('Bearer ')) {
-      return reply.code(401).send(ApiError.invalidRequest('Missing or invalid Authorization header'));
-    }
-    const token = auth.slice('Bearer '.length);
-    try {
-      const payload = await verifyBearer(token);
-      (req as any).user = payload;
-    } catch {
-      return reply.code(401).send(ApiError.invalidToken('Invalid or expired token'));
-    }
-  };
+  const requireAuth = (requiredScope?: string) =>
+    async (req: any, reply: any) => {
+      const auth = req.headers.authorization;
+      if (!auth?.startsWith('Bearer ')) {
+        return reply.code(401).send(ApiError.invalidRequest('Missing or invalid Authorization header'));
+      }
+      const token = auth.slice('Bearer '.length);
+      try {
+        const payload = await verifyBearer(token);
+
+        if (requiredScope) {
+          const scopeString = payload.scope ?? '';
+          const scopes = scopeString.split(' ').map((s) => s.trim()).filter(Boolean);
+          if (!scopes.includes(requiredScope)) {
+            return reply.code(403).send(ApiError.insufficientScope(`Missing scope: ${requiredScope}`));
+          }
+        }
+
+        (req as any).user = payload;
+      } catch {
+        return reply.code(401).send(ApiError.invalidToken('Invalid or expired token'));
+      }
+    };
 
   // Routes
   await registerOAuthRoutes(app);

--- a/src/services/AccessControlService.ts
+++ b/src/services/AccessControlService.ts
@@ -6,6 +6,8 @@ import type { OAuthStoredToken } from '../models/OAuthToken';
 
 const secretKey = new TextEncoder().encode(config.JWT_SECRET);
 
+export type AccessTokenPayload = JWTPayload & { scope?: string };
+
 export async function issueAccessToken(subject: string, scope?: string): Promise<{
   token: string;
   expiresIn: number;
@@ -31,7 +33,7 @@ export async function issueAccessToken(subject: string, scope?: string): Promise
   return { token, expiresIn: config.ACCESS_TOKEN_TTL };
 }
 
-export async function verifyBearer(token: string): Promise<JWTPayload> {
+export async function verifyBearer(token: string): Promise<AccessTokenPayload> {
   TokenDao.pruneExpired();
   const rec = TokenDao.getByToken(token);
   if (!rec) {
@@ -55,7 +57,7 @@ export async function verifyBearer(token: string): Promise<JWTPayload> {
     throw e;
   }
 
-  return payload;
+  return payload as AccessTokenPayload;
 }
 
 export function validateClient(id?: string, secret?: string): boolean {


### PR DESCRIPTION
## Summary
- add scope-aware auth middleware and require the `user` scope on user routes
- ensure the OAuth token endpoint issues tokens with requested scopes by defaulting to the new `user` scope
- extend BDD coverage to verify scope enforcement for both read and write user operations

## Testing
- npm run bdd
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dabda890a4832fb35023d22ab11126